### PR TITLE
"toutf8" breaks on ruby 1.9.2p180

### DIFF
--- a/lib/gstore/request.rb
+++ b/lib/gstore/request.rb
@@ -56,7 +56,7 @@ module GStore
       canonical_resource += path
       canonical_resource += '?acl' if params[:acl]
       
-      authorization = 'GOOG1 ' + @access_key + ':' + sign((canonical_headers + canonical_resource).toutf8)
+      authorization = 'GOOG1 ' + @access_key + ':' + sign((canonical_headers + canonical_resource).encode("UTF-8"))
       
       if @debug
         puts


### PR DESCRIPTION
I have ruby 1.9.2p180 (2011-02-18) [i386-mingw32] running, and the "toutf8" method in the signed_request method of request.rb breaks.  Looks like I'm using the latest version of Ruby on Windows.

This is my first time making a pull request; please forgive any lack of etiquette!
